### PR TITLE
Fix: temporary fix comments in comprehesions for kubevela

### DIFF
--- a/internal/core/export/extract.go
+++ b/internal/core/export/extract.go
@@ -58,6 +58,15 @@ func extractDocs(v *adt.Vertex, a []adt.Conjunct) (docs []*ast.CommentGroup) {
 			if c := internal.FileComment(f); c != nil {
 				docs = append(docs, c)
 			}
+
+		default:
+			if f != nil {
+				for _, cg := range f.Comments() {
+					if !containsDoc(docs, cg) && cg.Doc {
+						docs = append(docs, cg)
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: FogDong <dongtianxin.tx@alibaba-inc.com>

Fix kubevela/kubevela#4993

Note that this is only a temporary fix for https://github.com/cue-lang/cue/issues/2062 , this fix only fix the case in `vertex` but not in `def` but will fix the scenario for kubevela temporarily. 

The fix should be replaced by the CUE official fix later.